### PR TITLE
Bump MSRV to 1.75.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     strategy:
       matrix:
-        toolchain: [stable, beta, nightly, "1.69.0"]
+        toolchain: [stable, beta, nightly, "1.75.0"]
 
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.toolchain != 'stable' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-rust-version = "1.69.0"
+rust-version = "1.75.0"
 repository = "https://github.com/kpreid/rendiff/"
 
 [workspace.dependencies]


### PR DESCRIPTION
No strong reason for this other than keeping a version that is not older than the locked deps. In principle we should keep the lockfile low or rebuild it or something, but I don’t want to bother for now.