### PR TITLE
Improve diff image.

### DIFF
--- a/rendiff/src/histogram.rs
+++ b/rendiff/src/histogram.rs
@@ -18,6 +18,18 @@ pub struct Histogram(pub [usize; 256]);
 impl Histogram {
     /// The histogram with all bins zero.
     pub const ZERO: Self = Self([0; 256]);
+
+    /// Returns the maximum difference; that is, the index of the highest nonzero entry.
+    ///
+    /// Returns zero if the histogram is entirely empty.
+    #[must_use]
+    pub fn max_difference(&self) -> u8 {
+        match self.0.iter().rposition(|&count| count != 0) {
+            #[allow(clippy::cast_possible_truncation)] // impossible
+            Some(position) => position as u8,
+            None => 0,
+        }
+    }
 }
 
 impl fmt::Debug for Histogram {
@@ -69,6 +81,23 @@ mod tests {
         assert_eq!(
             format!("{histogram:#?}"),
             "Histogram(Δ0 ×1000, Δ10 ×5, Δ50 ×1)"
+        );
+    }
+
+    #[test]
+    fn max_difference() {
+        assert_eq!(Histogram::ZERO.max_difference(), 0);
+        assert_eq!(Histogram([10; 256]).max_difference(), 255);
+        assert_eq!(
+            {
+                let mut h = [0; 256];
+                h[0] = 1000;
+                h[10] = 5;
+                h[50] = 1;
+                Histogram(h)
+            }
+            .max_difference(),
+            50,
         );
     }
 }

--- a/rendiff/src/lib.rs
+++ b/rendiff/src/lib.rs
@@ -78,3 +78,5 @@ pub use histogram::*;
 
 mod threshold;
 pub use threshold::*;
+
+mod visualize;

--- a/rendiff/src/visualize.rs
+++ b/rendiff/src/visualize.rs
@@ -1,0 +1,39 @@
+use image::{GrayImage, Pixel, Rgba, RgbaImage};
+
+use crate::Histogram;
+
+/// Take the raw absolute-difference values and visualize them
+/// (by making small values more visible).
+pub(crate) fn visualize(
+    reference: &RgbaImage,
+    raw_diff_image: &GrayImage,
+    histogram: &Histogram,
+) -> RgbaImage {
+    // Validate the assumption our `(x + 1, y + 1)` coordinate lookups are making.
+    // This will fail if we change how the diff algorithm works and don't update this.
+    debug_assert_eq!(
+        (reference.width(), reference.height()),
+        (raw_diff_image.width() + 2, raw_diff_image.height() + 2)
+    );
+
+    let max_difference = f64::from(histogram.max_difference());
+
+    RgbaImage::from_fn(raw_diff_image.width(), raw_diff_image.height(), |x, y| {
+        let image::Luma([reference_value]) = reference.get_pixel(x + 1, y + 1).to_luma();
+
+        // Scale up the diff values to maximize contrast
+        let &image::Luma([raw_diff_value]) = raw_diff_image.get_pixel(x, y);
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let amplified_difference = (f64::from(raw_diff_value) / max_difference * 255.0) as u8;
+
+        Rgba([
+            // Make the reference image low-contrast (in the red channel and scaled down),
+            // so that it doesn't distract from the diff pixels but just gives visual context
+            // for the spatial position of the differences.
+            reference_value / 3,
+            amplified_difference,
+            amplified_difference,
+            255,
+        ])
+    })
+}


### PR DESCRIPTION
* Scale the differences up to use all available dynamic range.
* Include the expected image, dimly, in red, while the diff is in the green and blue channels. This provides context for determining which pixels of the content are involved.
* Also fix one expected/actual confusion in the test code, since there is now a difference in how they are treated.

Further work in this direction could include distinguishing between differences that are below the comparison `Threshold`, and those that are above.

Part of <https://github.com/kpreid/rendiff/issues/6>.