### PR TITLE
Use image types from `imgref` instead of `image`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "rendiff"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "embed-doc-image",
  "image",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "rendiff-cli"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "imgref"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126"
+
+[[package]]
+name = "interop"
+version = "0.0.0"
+dependencies = [
+ "image",
+ "imgref",
+]
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +411,8 @@ version = "0.2.0"
 dependencies = [
  "embed-doc-image",
  "image",
+ "imgref",
+ "interop",
 ]
 
 [[package]]
@@ -406,6 +422,8 @@ dependencies = [
  "anyhow",
  "clap",
  "image",
+ "imgref",
+ "interop",
  "mutants",
  "rendiff",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ rust-version = "1.75.0"
 repository = "https://github.com/kpreid/rendiff/"
 
 [workspace.dependencies]
+rendiff = { version = "0.2.0", path = "rendiff/" }
+
 embed-doc-image = { version = "0.1.4" }
 image = { version = "0.24.6", default-features = false }
 mutants = "0.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,9 @@
 resolver = "2"
 members = [
     "rendiff",
-    "cli",
+
+    "cli", # example
+    "interop", # test helper
 ]
 
 [workspace.package]
@@ -12,6 +14,8 @@ repository = "https://github.com/kpreid/rendiff/"
 [workspace.dependencies]
 rendiff = { version = "0.2.0", path = "rendiff/" }
 
+interop = { path = "interop/" }
 embed-doc-image = { version = "0.1.4" }
 image = { version = "0.24.6", default-features = false }
+imgref = { version = "1.10.1", default-features = false }
 mutants = "0.0.3"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Packages in this repository
 
 * `rendiff/` is the library containing the algorithm.
 * `cli/` (package name `rendiff-cli`) is a command-line tool to run the algorithm on pairs of image files.
+* `interop/` is used only for shared code in this workspace.
 
 License
 -------

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "rendiff-cli"
-version = "0.1.0"
 edition = "2021"
 rust-version = { workspace = true }
 repository = { workspace = true }
@@ -17,4 +16,4 @@ anyhow = "1.0.70"
 clap = { version = "4.2.4", default-features = false, features = ["derive", "help", "std", "usage", "wrap_help"] }
 image = { workspace = true, default-features = true }
 mutants = { workspace = true }
-rendiff = { version = "0.1.0", path = "../rendiff/" }
+rendiff = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,5 +15,7 @@ doc = false
 anyhow = "1.0.70"
 clap = { version = "4.2.4", default-features = false, features = ["derive", "help", "std", "usage", "wrap_help"] }
 image = { workspace = true, default-features = true }
+imgref = { workspace = true }
+interop = { workspace = true }
 mutants = { workspace = true }
 rendiff = { workspace = true }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -30,13 +30,13 @@ fn main() -> anyhow::Result<ExitCode> {
         diff: diff_path,
     } = Args::parse();
 
-    let actual = open_with_context("actual image", &actual)?;
-    let expected = open_with_context("expected image", &expected)?;
+    let actual = interop::from_rgba(open_with_context("actual image", &actual)?);
+    let expected = interop::from_rgba(open_with_context("expected image", &expected)?);
 
-    let difference = rendiff::diff(&actual, &expected);
+    let difference = rendiff::diff(actual.as_ref(), expected.as_ref());
 
     if let (Some(diff_image), Some(diff_path)) = (&difference.diff_image, &diff_path) {
-        diff_image
+        interop::into_rgba(diff_image.clone())
             .save(&diff_path)
             .with_context(|| format!("failed to write '{}'", diff_path.display()))?;
     }

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "interop"
+edition = "2021"
+rust-version.workspace = true
+repository.workspace = true
+description = "Conversion between `image` and `imgref` data types."
+publish = false # only used within this workspace
+
+[lib]
+bench = false
+doctest = false
+
+[dependencies]
+image = { workspace = true }
+imgref = { workspace = true }

--- a/interop/src/lib.rs
+++ b/interop/src/lib.rs
@@ -1,0 +1,29 @@
+/// Converts RGBA [`image`] image to [`imgref`] image with identical pixel bytes.
+pub fn from_rgba(image: image::RgbaImage) -> imgref::ImgVec<[u8; 4]> {
+    // These conversions cannot fail because if they didn't fit in `usize`,
+    // the `buf` couldn't exist in memory.
+    let width = usize::try_from(image.width()).expect("width too large");
+    let height = usize::try_from(image.height()).expect("height too large");
+
+    let buf = image
+        .into_vec()
+        .chunks(4)
+        .map(|pixel| <[u8; 4]>::try_from(pixel).unwrap())
+        .collect();
+
+    imgref::ImgVec::new(buf, width, height)
+}
+
+/// Converts RGBA [`imgref`] image to [`image`] image with identical pixel bytes.
+pub fn into_rgba(image: imgref::ImgVec<[u8; 4]>) -> image::RgbaImage {
+    let (buf, width, height) = image.into_contiguous_buf();
+
+    // These conversions cannot fail because `imgref` has an (undocumented)
+    // restriction that the dimensions must fit in `u32` as well as `usize`.
+    let width = u32::try_from(width).expect("width too large");
+    let height = u32::try_from(height).expect("height too large");
+
+    let buf = buf.into_iter().flatten().collect();
+
+    image::RgbaImage::from_vec(width, height, buf).unwrap()
+}

--- a/rendiff/CHANGELOG.md
+++ b/rendiff/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0 (release date TBD)
+
+### Breaking changes
+
+TODO: Fill in this section
+
 ## 0.1.1 (2024-06-08)
 
 ### Added

--- a/rendiff/CHANGELOG.md
+++ b/rendiff/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-TODO: Fill in this section
+* No longer depends on the `image` package; all image types have been replaced with the much stabler [`imgref`](https://docs.rs/imgref/1/).
 
 ## 0.1.1 (2024-06-08)
 

--- a/rendiff/CHANGELOG.md
+++ b/rendiff/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## 0.2.0 (release date TBD)
 
-### Breaking changes
+This release consists of the following **breaking changes**:
 
 * No longer depends on the `image` package; all image types have been replaced with the much stabler [`imgref`](https://docs.rs/imgref/1/).
+* `Difference` and `Threshold` no longer have public fields.
+    * `Difference` provides accessors instead.
+    * `Threshold` is write-only.
 
 ## 0.1.1 (2024-06-08)
 

--- a/rendiff/Cargo.toml
+++ b/rendiff/Cargo.toml
@@ -9,8 +9,11 @@ license = "MIT OR Apache-2.0"
 categories = ["development-tools::testing", "game-development", "multimedia::images", "rendering"]
 
 [dependencies]
-image = { workspace = true, default-features = false }
 embed-doc-image = { workspace = true }
+imgref = { workspace = true, default-features = false }
 
 [dev-dependencies]
-image = { workspace = true, features = ["png"] }
+# used to load images for tests
+image = { workspace = true, default-features = false, features = ["png"] }
+interop = { workspace = true }
+

--- a/rendiff/Cargo.toml
+++ b/rendiff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rendiff"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = { workspace = true }
 repository = { workspace = true }

--- a/rendiff/src/diff.rs
+++ b/rendiff/src/diff.rs
@@ -6,9 +6,17 @@ use crate::{Histogram, RgbaPixel};
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
 pub struct Difference {
-    // TODO: Make these fields private so we have more flexibility.
+    histogram: Histogram,
+
+    diff_image: Option<imgref::ImgVec<RgbaPixel>>,
+}
+
+impl Difference {
     /// A histogram of magnitudes of the detected differences.
-    pub histogram: Histogram,
+    #[must_use]
+    pub fn histogram(&self) -> Histogram {
+        self.histogram
+    }
 
     /// An sRGB RGBA image intended for human viewing of which pixels are different,
     /// or [`None`] if the images had different sizes.
@@ -18,7 +26,10 @@ pub struct Difference {
     ///
     /// Currently, the red channel contains data from the input `expected` image,
     /// and the blue and green channels contain differences, scaled up for high visibility.
-    pub diff_image: Option<imgref::ImgVec<RgbaPixel>>,
+    #[must_use]
+    pub fn diff_image(&self) -> Option<ImgRef<'_, RgbaPixel>> {
+        self.diff_image.as_ref().map(imgref::ImgExt::as_ref)
+    }
 }
 
 /// Compares two RGBA images with a neighborhood-sensitive comparison which counts one pixel worth

--- a/rendiff/src/histogram.rs
+++ b/rendiff/src/histogram.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 /// A [histogram] of color difference values.
 ///

--- a/rendiff/src/image.rs
+++ b/rendiff/src/image.rs
@@ -1,0 +1,45 @@
+//! Image manipulation functions built on [`imgref`].
+
+use crate::RgbaPixel;
+
+pub(crate) fn from_fn<T>(
+    width: usize,
+    height: usize,
+    mut f: impl FnMut(usize, usize) -> T,
+) -> imgref::ImgVec<T> {
+    imgref::ImgVec::new(
+        (0..height)
+            .flat_map(|y| (0..width).map(move |x| (x, y)))
+            .map(|(x, y)| f(x, y))
+            .collect(),
+        width,
+        height,
+    )
+}
+
+pub(crate) fn rgba_to_luma(pixel: RgbaPixel) -> u8 {
+    // Legacy compatibility: this is the formula `image`'s internal `rgb_to_luma()` uses.
+    // However, this is ill-founded, because sRGB encoded values are non-linear, so the weighting
+    // effectively varies depending on the level. It gives us luma, not luminance (see
+    // <https://en.wikipedia.org/wiki/Luma_(video)> for an explanation) but for our purposes,
+    // this is not necessarily what we actually want.
+    //
+    // What we in principle should be doing instead is decoding (linearizing),
+    // performing the weighted sum, then encoding again.
+    // But that should not just replace this function; rather we should consider what each use case
+    // actually needs.
+
+    let [r, g, b, _a] = pixel;
+    let luma: u32 = (2126 * u32::from(r) + 7152 * u32::from(g) + 722 * u32::from(b)) / 10000;
+
+    debug_assert!(u8::try_from(luma).is_ok());
+    #[allow(clippy::cast_possible_truncation)]
+    {
+        luma as u8
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn luma_to_rgba(luma: u8) -> RgbaPixel {
+    [luma, luma, luma, 255]
+}

--- a/rendiff/src/lib.rs
+++ b/rendiff/src/lib.rs
@@ -94,6 +94,13 @@
 #![warn(unreachable_pub)]
 #![warn(unused_lifetimes)]
 
+/// `rendiff` uses image types from `imgref`.
+pub use ::imgref;
+
+type RgbaPixel = [u8; 4];
+
+mod image;
+
 mod diff;
 pub use diff::*;
 

--- a/rendiff/src/threshold.rs
+++ b/rendiff/src/threshold.rs
@@ -9,7 +9,7 @@ use crate::Histogram;
 /// towards the limit at a higher magnitude. Differences of zero are always accepted.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[allow(clippy::exhaustive_structs)]
-pub struct Threshold(pub BTreeMap<u8, usize>);
+pub struct Threshold(BTreeMap<u8, usize>);
 
 impl Threshold {
     /// Creates a [`Threshold`] from a list of (magnitude, count) entries.

--- a/rendiff/src/visualize.rs
+++ b/rendiff/src/visualize.rs
@@ -1,14 +1,14 @@
-use image::{GrayImage, Pixel, Rgba, RgbaImage};
+use imgref::{ImgRef, ImgVec};
 
-use crate::Histogram;
+use crate::{Histogram, RgbaPixel};
 
 /// Take the raw absolute-difference values and visualize them
 /// (by making small values more visible).
 pub(crate) fn visualize(
-    reference: &RgbaImage,
-    raw_diff_image: &GrayImage,
+    reference: ImgRef<'_, RgbaPixel>,
+    raw_diff_image: ImgRef<'_, u8>,
     histogram: &Histogram,
-) -> RgbaImage {
+) -> ImgVec<RgbaPixel> {
     // Validate the assumption our `(x + 1, y + 1)` coordinate lookups are making.
     // This will fail if we change how the diff algorithm works and don't update this.
     debug_assert_eq!(
@@ -18,15 +18,16 @@ pub(crate) fn visualize(
 
     let max_difference = f64::from(histogram.max_difference());
 
-    RgbaImage::from_fn(raw_diff_image.width(), raw_diff_image.height(), |x, y| {
-        let image::Luma([reference_value]) = reference.get_pixel(x + 1, y + 1).to_luma();
+    crate::image::from_fn(raw_diff_image.width(), raw_diff_image.height(), |x, y| {
+        // TODO: this should be re-encoded luminance, not luma
+        let reference_value = crate::image::rgba_to_luma(reference[(x + 1, y + 1)]);
 
         // Scale up the diff values to maximize contrast
-        let &image::Luma([raw_diff_value]) = raw_diff_image.get_pixel(x, y);
+        let raw_diff_value = raw_diff_image[(x, y)];
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let amplified_difference = (f64::from(raw_diff_value) / max_difference * 255.0) as u8;
 
-        Rgba([
+        [
             // Make the reference image low-contrast (in the red channel and scaled down),
             // so that it doesn't distract from the diff pixels but just gives visual context
             // for the spatial position of the differences.
@@ -34,6 +35,6 @@ pub(crate) fn visualize(
             amplified_difference,
             amplified_difference,
             255,
-        ])
+        ]
     })
 }

--- a/rendiff/tests/diff-examples.rs
+++ b/rendiff/tests/diff-examples.rs
@@ -15,7 +15,7 @@ fn diff_example_robot() {
     let difference = rendiff::diff(input_actual.as_ref(), input_expected.as_ref());
 
     assert_eq!(
-        difference.histogram,
+        difference.histogram(),
         rendiff::Histogram({
             let mut h = [0; 256];
             h[85] = 20;
@@ -26,8 +26,8 @@ fn diff_example_robot() {
         })
     );
     assert_eq!(
-        expected_diff,
-        difference.diff_image.expect("should have diff image")
+        expected_diff.as_ref(),
+        difference.diff_image().expect("should have diff image")
     );
 }
 

--- a/rendiff/tests/diff-examples.rs
+++ b/rendiff/tests/diff-examples.rs
@@ -8,11 +8,11 @@ use std::path::Path;
 fn diff_example_robot() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("example-comparisons");
     eprintln!("Dir: {root:?}");
-    let input_actual = image::open(dbg!(root.join("robot-actual.png"))).unwrap();
-    let input_expected = image::open(root.join("robot-exp.png")).unwrap();
-    let expected_diff = image::open(root.join("robot-diff.png")).unwrap();
+    let input_actual = load_and_convert(&dbg!(root.join("robot-actual.png"))).unwrap();
+    let input_expected = load_and_convert(&root.join("robot-exp.png")).unwrap();
+    let expected_diff = load_and_convert(&root.join("robot-diff.png")).unwrap();
 
-    let difference = rendiff::diff(&input_actual.to_rgba8(), &input_expected.to_rgba8());
+    let difference = rendiff::diff(input_actual.as_ref(), input_expected.as_ref());
 
     assert_eq!(
         difference.histogram,
@@ -26,7 +26,11 @@ fn diff_example_robot() {
         })
     );
     assert_eq!(
-        expected_diff.to_rgba8(),
+        expected_diff,
         difference.diff_image.expect("should have diff image")
     );
+}
+
+fn load_and_convert(path: &Path) -> Result<imgref::ImgVec<[u8; 4]>, image::ImageError> {
+    Ok(interop::from_rgba(image::open(path)?.to_rgba8()))
 }


### PR DESCRIPTION
`image` publishes incompatible versions not infrequently. Therefore, it is not a good choice as a dependency that appears in our public API. `imgref`, on the other hand, is explicitly minimal, and has existed for years at 1.x.

Unfortunately, this means that users of `rendiff` have to perform conversions, but they would have had to do that anyway if their version of `image` is not the same as ours.

Implements #3 and #18.