### PR TITLE
Optimize `half_diff()` code.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "image",
  "imgref",
  "interop",
+ "mutants",
 ]
 
 [[package]]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::time::Instant;
 
 use anyhow::Context;
 use clap::Parser;
@@ -33,7 +34,17 @@ fn main() -> anyhow::Result<ExitCode> {
     let actual = interop::from_rgba(open_with_context("actual image", &actual)?);
     let expected = interop::from_rgba(open_with_context("expected image", &expected)?);
 
+    let t_start = Instant::now();
+
     let difference = rendiff::diff(actual.as_ref(), expected.as_ref());
+
+    let t_finish_diff = Instant::now();
+    eprintln!(
+        "Time: {elapsed:?} to calculate diff of {w}×{h} image",
+        elapsed = t_finish_diff.saturating_duration_since(t_start),
+        w = actual.width(),
+        h = actual.height(),
+    );
 
     if let (Some(diff_image), Some(diff_path)) = (difference.diff_image(), &diff_path) {
         interop::into_rgba(diff_image.map_buf(ToOwned::to_owned))

--- a/rendiff/Cargo.toml
+++ b/rendiff/Cargo.toml
@@ -16,4 +16,5 @@ imgref = { workspace = true, default-features = false }
 # used to load images for tests
 image = { workspace = true, default-features = false, features = ["png"] }
 interop = { workspace = true }
+mutants = { workspace = true }
 

--- a/rendiff/src/diff.rs
+++ b/rendiff/src/diff.rs
@@ -114,12 +114,26 @@ fn half_diff(have: ImgRef<'_, RgbaPixel>, want: ImgRef<'_, RgbaPixel>) -> ImgVec
         .enumerate()
         .flat_map(|(y, row)| row.iter().enumerate().map(move |(x, &pixel)| (x, y, pixel)))
     {
+        // Note on coordinates:
         // The x and y we get from the enumerate()s start at (0, 0) ignoring our offset,
         // so when we use those same x,y as top-left corner of the neighborhood,
         // we get a centered neighborhood.
-        let neighborhood = want.sub_image(x, y, 3, 3);
+        //
+        // Note on performance: this mess of explicit indexing proved faster than
+        // `want.sub_image().pixels()`, and also faster than iterating over slices.
+        let neighborhood = [
+            want[(x, y)],
+            want[(x + 1, y)],
+            want[(x + 2, y)],
+            want[(x, y + 1)],
+            want[(x + 1, y + 1)],
+            want[(x + 2, y + 1)],
+            want[(x, y + 2)],
+            want[(x + 1, y + 2)],
+            want[(x + 2, y + 2)],
+        ];
         let minimum_diff_in_neighborhood: u8 = neighborhood
-            .pixels()
+            .into_iter()
             .map(|want_pixel| pixel_diff(have_pixel, want_pixel))
             .min()
             .expect("neighborhood is never empty");

--- a/rendiff/src/diff.rs
+++ b/rendiff/src/diff.rs
@@ -109,35 +109,33 @@ fn half_diff(have: ImgRef<'_, RgbaPixel>, want: ImgRef<'_, RgbaPixel>) -> ImgVec
     let have_elems = have.sub_image(1, 1, have.width() - 2, have.height() - 2);
 
     let mut buffer: Vec<u8> = Vec::with_capacity(have_elems.width() * have_elems.height());
-    for (x, y, have_pixel) in have_elems
-        .rows()
-        .enumerate()
-        .flat_map(|(y, row)| row.iter().enumerate().map(move |(x, &pixel)| (x, y, pixel)))
-    {
-        // Note on coordinates:
-        // The x and y we get from the enumerate()s start at (0, 0) ignoring our offset,
-        // so when we use those same x,y as top-left corner of the neighborhood,
-        // we get a centered neighborhood.
-        //
-        // Note on performance: this mess of explicit indexing proved faster than
-        // `want.sub_image().pixels()`, and also faster than iterating over slices.
-        let neighborhood = [
-            want[(x, y)],
-            want[(x + 1, y)],
-            want[(x + 2, y)],
-            want[(x, y + 1)],
-            want[(x + 1, y + 1)],
-            want[(x + 2, y + 1)],
-            want[(x, y + 2)],
-            want[(x + 1, y + 2)],
-            want[(x + 2, y + 2)],
-        ];
-        let minimum_diff_in_neighborhood: u8 = neighborhood
-            .into_iter()
-            .map(|want_pixel| pixel_diff(have_pixel, want_pixel))
-            .min()
-            .expect("neighborhood is never empty");
-        buffer.push(minimum_diff_in_neighborhood);
+    for (y, have_row) in have_elems.rows().enumerate() {
+        for (x, &have_pixel) in have_row.iter().enumerate() {
+            // Note on coordinates:
+            // The x and y we get from the enumerate()s start at (0, 0) ignoring our offset,
+            // so when we use those same x,y as top-left corner of the neighborhood,
+            // we get a centered neighborhood.
+            //
+            // Note on performance: this mess of explicit indexing proved faster than
+            // `want.sub_image().pixels()`, and also faster than iterating over slices.
+            let neighborhood = [
+                want[(x, y)],
+                want[(x + 1, y)],
+                want[(x + 2, y)],
+                want[(x, y + 1)],
+                want[(x + 1, y + 1)],
+                want[(x + 2, y + 1)],
+                want[(x, y + 2)],
+                want[(x + 1, y + 2)],
+                want[(x + 2, y + 2)],
+            ];
+            let minimum_diff_in_neighborhood: u8 = neighborhood
+                .into_iter()
+                .map(|want_pixel| pixel_diff(have_pixel, want_pixel))
+                .min()
+                .expect("neighborhood is never empty");
+            buffer.push(minimum_diff_in_neighborhood);
+        }
     }
 
     ImgVec::new(buffer, have_elems.width(), have_elems.height())

--- a/rendiff/src/diff.rs
+++ b/rendiff/src/diff.rs
@@ -108,7 +108,7 @@ fn dimensions<T>(image: imgref::ImgRef<'_, T>) -> [usize; 2] {
 fn half_diff(have: ImgRef<'_, RgbaPixel>, want: ImgRef<'_, RgbaPixel>) -> ImgVec<u8> {
     let have_elems = have.sub_image(1, 1, have.width() - 2, have.height() - 2);
 
-    let mut buffer: Vec<u8> = Vec::new();
+    let mut buffer: Vec<u8> = Vec::with_capacity(have_elems.width() * have_elems.height());
     for (x, y, have_pixel) in have_elems
         .rows()
         .enumerate()


### PR DESCRIPTION
These changes reduce the time taken to diff an 1442×1250 test image from ~280 ms to ~110 ms.

Fixes #26.