### PR TITLE
Optimize: In `half_diff`, use `extend()` per image row instead of `push()` per pixel.

### DIFF
--- a/rendiff/src/diff.rs
+++ b/rendiff/src/diff.rs
@@ -117,7 +117,7 @@ fn half_diff(have: ImgRef<'_, RgbaPixel>, want: ImgRef<'_, RgbaPixel>) -> ImgVec
             std::array::from_fn(|_| iter.next().unwrap_or(/* unreachable */ &[]))
         };
 
-        for (x, &have_pixel) in have_row.iter().enumerate() {
+        buffer.extend(have_row.iter().enumerate().map(move |(x, &have_pixel)| {
             // Note on coordinates:
             // The x and y we get from the enumerate()s start at (0, 0) ignoring our offset,
             // so when we use those same x,y as top-left corner of the neighborhood,
@@ -141,8 +141,8 @@ fn half_diff(have: ImgRef<'_, RgbaPixel>, want: ImgRef<'_, RgbaPixel>) -> ImgVec
                 .map(|want_pixel| pixel_diff(have_pixel, want_pixel))
                 .min()
                 .expect("neighborhood is never empty");
-            buffer.push(minimum_diff_in_neighborhood);
-        }
+            minimum_diff_in_neighborhood
+        }));
     }
 
     ImgVec::new(buffer, have_elems.width(), have_elems.height())


### PR DESCRIPTION
I intended this to be preliminary refactoring, but it turns out to make a large performance improvement (110 ms to 75 ms) by itself. The improvement is fragile and goes away with other small changes, which suggests that it might be an accident of machine code generation more than a reliable improvement, but getting rid of the `push()`es seems like a better state for future work, so even if they're really just equivalent, I'll take this.