### PR TITLE
Remove no-op `.max(255u8)`.

### DIFF
--- a/rendiff/src/diff.rs
+++ b/rendiff/src/diff.rs
@@ -163,7 +163,7 @@ fn pixel_diff(a: RgbaPixel, b: RgbaPixel) -> u8 {
 
     let color_diff = crate::image::rgba_to_luma([r_diff, g_diff, b_diff, 255]);
 
-    color_diff.max(a_diff).min(255)
+    color_diff.max(a_diff)
 }
 
 #[cfg_attr(test, mutants::skip)] // Not really testable.


### PR DESCRIPTION
This slipped in at commit 2ece5498c9d3dabdfaf1b799b4aef3397b07db42, probably because I was at one point using a larger than `u8` intermediate type.