### PR TITLE
Add `remove_allowed_differences_from()`, a new algorithm for evaluating thresholds.

### DIFF
--- a/rendiff/CHANGELOG.md
+++ b/rendiff/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+* `Threshold::remove_allowed_differences_from()`, which can be used in place of `Threshold::allows()` to give more information about comparison failures than just the boolean.
+
+### Changed
+
+* A `Threshold`’s allowance of large magnitude differences now also applies to small magnitude differences which were not covered by entries for smaller magnitudes.
+
 ### Removed
 
 * Rust versions prior to 1.90.0 are no longer supported.

--- a/rendiff/src/threshold.rs
+++ b/rendiff/src/threshold.rs
@@ -110,7 +110,7 @@ mod tests {
 
     const H1: Histogram = {
         let mut h = [0; 256];
-        h[0] = 1000;
+        h[0] = 1000; // never matters
         h[1] = 30;
         h[10] = 5;
         h[50] = 1;
@@ -138,6 +138,17 @@ mod tests {
     fn almost_exact_fit() {
         // fails because not allowing two in the 50-100 range
         assert!(!Threshold::new([(1, 30), (10, 5), (100, 1)]).allows(H1));
+    }
+
+    #[test]
+    fn higher_value_threshold_can_apply_to_lower_error() {
+        assert!(
+            Threshold::new([
+                (1, 10),    // fewer 1s than H1 contains
+                (100, 100)  // should allow everything
+            ])
+            .allows(H1)
+        );
     }
 
     #[test]

--- a/rendiff/src/threshold.rs
+++ b/rendiff/src/threshold.rs
@@ -160,6 +160,21 @@ mod tests {
     fn simple_threshold() {
         assert_eq!(
             (
+                Threshold::no_bigger_than(99).remove_allowed_differences_from(H1),
+                Threshold::no_bigger_than(100).remove_allowed_differences_from(H1)
+            ),
+            (
+                {
+                    let mut h = [0; 256];
+                    h[100] = 1;
+                    Histogram(h)
+                },
+                Histogram::ZERO
+            )
+        );
+        // check that allows() agrees with remove_allowed_differences_from()
+        assert_eq!(
+            (
                 Threshold::no_bigger_than(99).allows(H1),
                 Threshold::no_bigger_than(100).allows(H1)
             ),
@@ -169,23 +184,35 @@ mod tests {
 
     #[test]
     fn exact_fit() {
-        assert!(Threshold::new([(1, 30), (10, 5), (50, 1), (100, 1)]).allows(H1));
+        assert_eq!(
+            Threshold::new([(1, 30), (10, 5), (50, 1), (100, 1)])
+                .remove_allowed_differences_from(H1),
+            Histogram::ZERO
+        );
     }
 
     #[test]
     fn almost_exact_fit() {
         // fails because not allowing two in the 50-100 range
-        assert!(!Threshold::new([(1, 30), (10, 5), (100, 1)]).allows(H1));
+        assert_eq!(
+            Threshold::new([(1, 30), (10, 5), (100, 1)]).remove_allowed_differences_from(H1),
+            {
+                let mut h = [0; 256];
+                h[50] = 1;
+                Histogram(h)
+            }
+        );
     }
 
     #[test]
     fn higher_value_threshold_can_apply_to_lower_error() {
-        assert!(
+        assert_eq!(
             Threshold::new([
                 (1, 10),    // fewer 1s than H1 contains
                 (100, 100)  // should allow everything
             ])
-            .allows(H1)
+            .remove_allowed_differences_from(H1),
+            Histogram::ZERO,
         );
     }
 
@@ -193,24 +220,43 @@ mod tests {
     fn total_count() {
         assert_eq!(
             (
-                Threshold::new([(100, 36)]).allows(H1),
-                Threshold::new([(100, 37)]).allows(H1)
+                Threshold::new([(100, 36)]).remove_allowed_differences_from(H1),
+                Threshold::new([(100, 37)]).remove_allowed_differences_from(H1)
             ),
-            (false, true)
+            (
+                {
+                    // It would be, in a sense, equally accurate to report `h[100] = 1`,
+                    // but that would be less informative about the level of the problem.
+                    let mut h = [0; 256];
+                    h[1] = 1;
+                    Histogram(h)
+                },
+                Histogram::ZERO
+            )
         );
     }
 
     #[test]
     fn max_threshold_allows_max_diff() {
-        assert!(Threshold::new([(255, 10)]).allows({
-            let mut h = [0; 256];
-            h[255] = 10;
-            Histogram(h)
-        }));
-        assert!(!Threshold::new([(255, 10)]).allows({
-            let mut h = [0; 256];
-            h[255] = 11;
-            Histogram(h)
-        }));
+        assert_eq!(
+            Threshold::new([(255, 10)]).remove_allowed_differences_from({
+                let mut h = [0; 256];
+                h[255] = 10;
+                Histogram(h)
+            }),
+            Histogram::ZERO,
+        );
+        assert_eq!(
+            Threshold::new([(255, 10)]).remove_allowed_differences_from({
+                let mut h = [0; 256];
+                h[255] = 11;
+                Histogram(h)
+            }),
+            {
+                let mut h = [0; 256];
+                h[255] = 1; // 11 in histogram - 10 in threshold = 1 remaining
+                Histogram(h)
+            },
+        );
     }
 }

--- a/rendiff/src/threshold.rs
+++ b/rendiff/src/threshold.rs
@@ -67,34 +67,72 @@ impl Threshold {
 
     /// Returns whether the differences described by the given [`Histogram`] are permitted
     /// by this [`Threshold`].
+    ///
+    /// This is equivalent to `self.remove_allowed_differences_from(histogram) == Histogram::ZERO`.
     #[must_use]
     pub fn allows(&self, histogram: Histogram) -> bool {
-        // Skip the first entry and always accept any number of zero-value differences.
-        let mut checked_up_to = 1;
-        // Loop over the thresholds, always in ascending order.
-        for (&level, &count) in &self.0 {
-            // Add 1 because the level value *includes* differences of that level, i.e.
-            // level 1 should include checking histogram[1].
-            let new_checked_up_to = usize::from(level) + 1;
-            debug_assert!(new_checked_up_to > checked_up_to);
-            let new_differences = histogram.0[checked_up_to..new_checked_up_to]
-                .iter()
-                .sum::<usize>();
-            if new_differences > count {
-                // TODO: Instead of failing immediately, buffer this and allow a later-checked
-                // higher-difference entry to also permit lower differences.
-                return false;
+        self.remove_allowed_differences_from(histogram) == Histogram::ZERO
+    }
+
+    /// Modify the given [`Histogram`] so that it does not include any of the differences which
+    /// this [`Threshold`] permits. The return value is the remaining, disallowed differences.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rendiff::{Histogram, Threshold};
+    ///
+    /// let histogram = Histogram({
+    ///     let mut table = [0; 256];
+    ///     table[1] = 1000;
+    ///     table[2] = 100;
+    ///     table[4] = 10;
+    ///     table
+    /// });
+    ///
+    /// // The histogram is allowed by this threshold, so `remove_allowed_differences_from`
+    /// // returns zero.
+    /// assert_eq!(
+    ///     Threshold::no_bigger_than(5).remove_allowed_differences_from(histogram),
+    ///     Histogram::ZERO,
+    /// );
+    ///
+    /// // This threshold is too small in both magnitude and count, so there is a remainder
+    /// // in bin 1 and bin 4 is passed through fully.
+    /// assert_eq!(
+    ///     Threshold::new([(3, 1050)]).remove_allowed_differences_from(histogram),
+    ///     Histogram({
+    ///         let mut table = [0; 256];
+    ///         table[1] = 50; // residual small difference
+    ///         table[4] = 10; // above threshold
+    ///         table
+    ///     }),
+    /// );
+    /// ```
+    #[must_use]
+    pub fn remove_allowed_differences_from(&self, mut histogram: Histogram) -> Histogram {
+        // Always accept any number of zero-value differences.
+        histogram.0[0] = 0;
+
+        // Loop over the thresholds, in ascending order so that we prefer spending low-magnitude
+        // allowance on low-magnitude differences instead of spending high-magnitude allowance on
+        // low-magnitude differences.
+        for (&allowed_magnitude, &(mut allowed_count)) in &self.0 {
+            // Slice the portion of the histogram that is affected.
+            let affected_region_of_histogram = &mut histogram.0[1..=usize::from(allowed_magnitude)];
+
+            // Subtract all allowed differences from both the histogram and the threshold.
+            // This is done in descending order of magnitude, so that the final result will favor
+            // reporting excess small differences not covered by a high-magnitude allowance over
+            // reporting excess large differences that look like they should have been covered.
+            for h_count in affected_region_of_histogram.iter_mut().rev() {
+                let deduction: usize = (*h_count).min(allowed_count);
+                *h_count -= deduction;
+                allowed_count -= deduction;
             }
-            checked_up_to = new_checked_up_to;
         }
 
-        // Finally, reject differences greater than any accepted.
-        let remaining_differences = histogram.0[checked_up_to..].iter().sum::<usize>();
-        if remaining_differences > 0 {
-            return false;
-        }
-
-        true
+        histogram
     }
 }
 


### PR DESCRIPTION
This new algorithm:

* Allows small magnitude differences to be permitted by higher magnitude entries in the `Threshold` (fixing the deleted TODO comment).
* Is able to report information about *why* an `allows()` passed or failed.

`allows()` is still present for API compatibility.